### PR TITLE
Fix compile error on "%x."

### DIFF
--- a/qrintf-pp
+++ b/qrintf-pp
@@ -65,7 +65,7 @@ sub rewrite_sprintf {
 
     # build the expr
     my $expr = "_qrintf_init($dst)$space_after_dst$space_before_fmt";
-    for my $token (split /(%-?0?(?:[0-9]+|\*|)(?:(?:h||l|ll|z)u|(?:h||l|ll)[di]|s|c))/, $fmt) {
+    for my $token (split /(%-?0?(?:[0-9]+|\*|)(?:(?:h||l|ll|z)[uxX]|(?:h||l|ll)[di]|s|c))/, $fmt) {
         if ($token =~ /^%(.*)$/) {
             my ($left_adjust, $zero_pad, $width, $conv) = ($token =~ /^%(-?)(0?)([0-9]+|\*|)(.*)$/)
                 or die "failed to parse token: $token";

--- a/t/test.c
+++ b/t/test.c
@@ -73,6 +73,7 @@ void test_simple()
     CHECK("%*s", (size_t)3, "a");
     CHECK("%*s", (size_t)3, "abc");
     CHECK("%*s", (size_t)3, "abcde");
+    CHECK("%x_", 1);
 
 #define CHECK_MULTI(type, conv, min, max) \
     CHECK(conv, (type)0); \


### PR DESCRIPTION
Hi,
I am facing following error with %x.

```
$ cat sprintf_x_dot.c
#include <stdio.h>

int main(int argc, char **argv)
{
    char buf[128] = {};
    sprintf(buf, "%x.", 10);
    sprintf(buf, "%xa", 10);
    return 0;
}
$ ./qrintf-gcc sprintf_x_dot.c
sprintf_x_dot.c: In function 'main':
sprintf_x_dot.c:6:32: error: expected identifier before '(' token
     sprintf(buf, "%x.", 10);
                                ^
sprintf_x_dot.c:7:5: error: incompatible type for argument 1 of '_qrintf_finalize'
     sprintf(buf, "%xa", 10);
     ^
In file included from <command-line>:1:0:
././qrintf.h:58:19: note: expected 'qrintf_t' but argument is of type 'int'
 static inline int _qrintf_finalize(qrintf_t ctx)
```

This PR fixed qrintf-pp to support %x correctly.
