### PR TITLE
Fix make install error, change the path to qrintf.h in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ gen:
 install:
 	install -d $(PREFIX)/bin $(PREFIX)/share/qrintf
 	install -m 755 bin/qrintf bin/qrintf-pp $(PREFIX)/bin
-	install -m 644 share/qrintf/qrintf.h $(PREFIX)/share/qrintf
+	install -m 644 include/qrintf.h $(PREFIX)/share/qrintf
 
 test:
 	bin/qrintf $(CC) -D_QRINTF_COUNT_CALL=1 -Wall -g -Werror t/test.c -o ./test && ./test


### PR DESCRIPTION
When running `make install`, I got the error.

```
$ sudo make install
install -d /usr/local/bin /usr/local/share/qrintf
install -m 755 bin/qrintf bin/qrintf-pp /usr/local/bin
install -m 644 share/qrintf/qrintf.h /usr/local/share/qrintf
install: cannot stat `share/qrintf/qrintf.h': No such file or directory
make: *** [install] Error 1
```

After applying this patch, `make install` works well. 

```
$ sudo make install
install -d /usr/local/bin /usr/local/share/qrintf
install -m 755 bin/qrintf bin/qrintf-pp /usr/local/bin
install -m 644 include/qrintf.h /usr/local/share/qrintf
```