### PR TITLE
add `test-cxx` target to test it in C++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,12 @@ install:
 	install -m 644 include/qrintf.h $(PREFIX)/include
 	install -m 755 share/qrintf/gcc-wrapper $(PREFIX)/share/qrintf
 
-test:
+test: test-cc test-cxx
+
+test-cc:
 	bin/qrintf $(CC) -D_QRINTF_COUNT_CALL=1 -Wall -g -Werror t/test.c -o ./test && ./test
 
-.PHONY: gen install test
+test-cxx:
+	bin/qrintf $(CXX) -x c++ -D_QRINTF_COUNT_CALL=1 -Wall -g -Werror t/test.c -o ./test && ./test
+
+.PHONY: gen install test test-cc test-cxx

--- a/include/qrintf.h
+++ b/include/qrintf.h
@@ -121,14 +121,14 @@ Exit:
     return ctx;
 }
 
-static inline qrintf_nck_t _qrintf_nck_fill(qrintf_nck_t ctx, int ch, size_t len, int width)
+static inline qrintf_nck_t _qrintf_nck_fill(qrintf_nck_t ctx, int ch, size_t len, size_t width)
 {
     for (; len < width; --width)
         ctx.str[ctx.off++] = ch;
     return ctx;
 }
 
-static inline qrintf_chk_t _qrintf_chk_fill(qrintf_chk_t ctx, int ch, size_t len, int width)
+static inline qrintf_chk_t _qrintf_chk_fill(qrintf_chk_t ctx, int ch, size_t len, size_t width)
 {
     if (len < width) {
         size_t off = ctx.off, l = width - len;

--- a/misc/gen-qrintf.h.pl
+++ b/misc/gen-qrintf.h.pl
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#! /usr/bin/env perl
 
 # Copyright (c) 2014,2015 DeNA Co., Ltd., Masahiro, Ide, Kazuho Oku
 #
@@ -257,14 +257,14 @@ Exit:
     return ctx;
 }
 
-static inline qrintf_nck_t _qrintf_nck_fill(qrintf_nck_t ctx, int ch, size_t len, int width)
+static inline qrintf_nck_t _qrintf_nck_fill(qrintf_nck_t ctx, int ch, size_t len, size_t width)
 {
     for (; len < width; --width)
         ctx.str[ctx.off++] = ch;
     return ctx;
 }
 
-static inline qrintf_chk_t _qrintf_chk_fill(qrintf_chk_t ctx, int ch, size_t len, int width)
+static inline qrintf_chk_t _qrintf_chk_fill(qrintf_chk_t ctx, int ch, size_t len, size_t width)
 {
     if (len < width) {
         size_t off = ctx.off, l = width - len;

--- a/t/test.c
+++ b/t/test.c
@@ -152,3 +152,9 @@ void test_composite()
 {
     CHECK("HTTP/1.1 %d %s", 200, "OK");
 }
+
+int main() {
+    subtest("test_simple", test_simple);
+    subtest("test_composite", test_composite);
+    return done_testing();
+}


### PR DESCRIPTION
Note that updating `picotest` and changing `test.c` are mandatory  because the current reference of `picotest` could not compile with C++.