### PR TITLE
add a failing test with commas and conditional operators

### DIFF
--- a/t/test.c
+++ b/t/test.c
@@ -91,6 +91,7 @@ void test_simple()
     CHECK("%s%d", "hi" /*hmm */, // test
         3);
     CHECK("%s%d", "a\",b", 123);
+    CHECK("%s", (1 ? "," : ""));
 
 #define CHECK_MULTI(type, conv, min, max) \
     CHECK(conv, (type)0); \


### PR DESCRIPTION
I've found a failing case on trying to compile [leveldb](https://github.com/google/leveldb) with `make check CC='qrintf clang' CXX='qrintf clang++'`.