### PR TITLE
Fix support clang when we use autotools

### DIFF
--- a/bin/qrintf
+++ b/bin/qrintf
@@ -62,11 +62,16 @@ if (basename($cc) =~ m{^g(?:cc|\+\+)}) {
 
     # splice "-o fn" from ARGV
     my $output_fn;
+    my $coption;
+
     for (my $i = 0; $i < @ARGV;) {
         if ($i + 1 < @ARGV && $ARGV[$i] eq '-o') {
             $output_fn = $ARGV[$i + 1];
             splice @ARGV, $i, 2;
         } else {
+	    if ($i + 1 < @ARGV && $ARGV[$i] eq '-c') {
+		$coption = 1;
+            }
             ++$i;
         }
     }
@@ -78,6 +83,10 @@ if (basename($cc) =~ m{^g(?:cc|\+\+)}) {
             && -e $ARGV[$i]                    # is a file
             && get_preprocessed_fn($ARGV[$i])  # is a file that is recognized as a source file
         ) {
+	    if($ARGV[$i] =~ /\.c$/ &&  !defined $output_fn && defined $coption) {
+		$output_fn = $ARGV[$i];
+		$output_fn =~ s/\.c$/\.o/;
+	    }
             push @files, splice @ARGV, $i, 1;
         } else {
             ++$i;


### PR DESCRIPTION
Hello.

When I build http://www.geocities.jp/kosako3/oniguruma/archive/onig-5.9.5.tar.gz using qrintf clang as CC command, I notice that ./configure miss understood C89 option.

This patch solves it.

Sorry, I can't explain easyliy in English.

I worte blog article at http://kjunichi.cocolog-nifty.com/misc/2015/07/qrintfclangauto.html

thank you.

by the way, I heard rebuildfm 99  It was very interesting.