### PR TITLE
Fix "_QRINTF_COUNT_CALL" is not defined warnings

### DIFF
--- a/include/qrintf.h
+++ b/include/qrintf.h
@@ -48,6 +48,10 @@ extern "C" {
 #undef snprintf
 #define snprintf(...) _qp_snprintf(__VA_ARGS__)
 
+#ifndef _QRINTF_COUNT_CALL
+#define _QRINTF_COUNT_CALL 0
+#endif
+
 #if _QRINTF_COUNT_CALL
 extern size_t _qrintf_call_cnt;
 #endif


### PR DESCRIPTION
Hi,

I get this warning when using qrintf with gcc 4.8.4 and -Wundef

```
In file included from <command-line>:0:0:
/usr/local/bin/../share/qrintf/../../include/qrintf.h:51:5: warning: "_QRINTF_COUNT_CALL" is not defined [-Wundef]
 #if _QRINTF_COUNT_CALL
     ^
/usr/local/bin/../share/qrintf/../../include/qrintf.h:71:5: warning: "_QRINTF_COUNT_CALL" is not defined [-Wundef]
 #if _QRINTF_COUNT_CALL
     ^
/usr/local/bin/../share/qrintf/../../include/qrintf.h:83:5: warning: "_QRINTF_COUNT_CALL" is not defined [-Wundef]
 #if _QRINTF_COUNT_CALL
     ^
```

This change ensures _QRINTF_COUNT_CALL is always defined.

Thanks,

Drew